### PR TITLE
Fix failing tests without jQuery

### DIFF
--- a/src/chaplin/views/collection_view.coffee
+++ b/src/chaplin/views/collection_view.coffee
@@ -194,7 +194,7 @@ module.exports = class CollectionView extends View
     # Set the listEl property with the actual list container.
     listSelector = _.result this, 'listSelector'
 
-    @listEl = if listSelector then @$(listSelector)[0] else @el
+    @listEl = if listSelector then @el.querySelector(listSelector) else @el
     @$list = Backbone.$ @listEl if Backbone.$
 
     @initFallback()
@@ -226,6 +226,7 @@ module.exports = class CollectionView extends View
 
     # Set the $fallback property.
     @$fallback = @$ @fallbackSelector
+    @fallback = @el.querySelector @fallbackSelector
 
     # Listen for visible items changes.
     @on 'visibilityChange', @toggleFallback
@@ -259,6 +260,7 @@ module.exports = class CollectionView extends View
 
     # Set the $loading property.
     @$loading = @$ @loadingSelector
+    @loading = @el.querySelector @loadingSelector
 
     # Listen for sync events on the collection.
     @listenTo @collection, 'syncStateChange', @toggleLoadingIndicator

--- a/src/chaplin/views/layout.coffee
+++ b/src/chaplin/views/layout.coffee
@@ -97,7 +97,7 @@ module.exports = class Layout extends View
   openLink: (event) =>
     return if utils.modifierKeyPressed(event)
 
-    el = if Backbone.$ then event.currentTarget else event.delegateTarget
+    el = event.currentTarget
     isAnchor = el.nodeName is 'A'
 
     # Get the href and perform checks on it.
@@ -115,7 +115,7 @@ module.exports = class Layout extends View
     skipRouting = @settings.skipRouting
     type = typeof skipRouting
     return if type is 'function' and not skipRouting(href, el) or
-      type is 'string' and (if Backbone.$ then Backbone.$(el).is(skipRouting) else el.matches skipRouting)
+      type is 'string' and utils.matchesSelector.call el, skipRouting
 
     # Handle external links.
     external = isAnchor and @isExternalLink el

--- a/src/chaplin/views/layout.coffee
+++ b/src/chaplin/views/layout.coffee
@@ -203,18 +203,13 @@ module.exports = class Layout extends View
 
     # Apply the region selector.
     instance.container = if region.selector is ''
-      if Backbone.$
-        region.instance.$el
-      else
-        region.instance.el
+      region.instance.el
     else
-      if region.instance.noWrap
-        if Backbone.$
-          Backbone.$(region.instance.container).find region.selector
+      root = if region.instance.noWrap
+          region.instance.container
         else
-          region.instance.container.querySelector region.selector
-      else
-        region.instance.$ region.selector
+          region.instance.el
+      root.querySelector region.selector
 
   # Disposal
   # --------

--- a/src/chaplin/views/layout.coffee
+++ b/src/chaplin/views/layout.coffee
@@ -97,7 +97,7 @@ module.exports = class Layout extends View
   openLink: (event) =>
     return if utils.modifierKeyPressed(event)
 
-    el = event.currentTarget
+    el = if Backbone.$ then event.currentTarget else event.delegateTarget
     isAnchor = el.nodeName is 'A'
 
     # Get the href and perform checks on it.

--- a/src/chaplin/views/view.coffee
+++ b/src/chaplin/views/view.coffee
@@ -155,7 +155,7 @@ module.exports = class View extends Backbone.View
       handler = if typeof value is 'function' then value else this[value]
       throw new Error "Method '#{value}' does not exist" unless handler
       match = key.match /^(\S+)\s*(.*)$/
-      eventName = "#{match[1]}.delegateEvents#{@cid}"
+      eventName = match[1]
       selector = match[2]
       bound = _.bind handler, this
       @delegate eventName, (selector or null), bound

--- a/test/initialize.js
+++ b/test/initialize.js
@@ -14,11 +14,10 @@ var testType = window.testType || (match ? match[1] : 'backbone');
 var useDeps = window.useDeps || (match ? match[2] : true);
 
 var addDeps = function() {
-  if (useDeps) {
-    paths.underscore = '../' + componentsFolder + '/lodash/lodash.compat';
+  if (useDeps === true) {
     paths.jquery = '../' + componentsFolder + '/jquery/jquery';
   } else {
-    paths.NativeView = '../' + componentsFolder + '/Backbone.NativeView/backbone.nativeview';
+    paths.NativeView = '../' + componentsFolder + '/backbone.nativeview/backbone.nativeview';
   }
 };
 if (testType === 'backbone') {
@@ -28,6 +27,8 @@ if (testType === 'backbone') {
   addDeps();
   paths.backbone = '../' + componentsFolder + '/exoskeleton/exoskeleton';
 }
+
+paths.underscore = '../' + componentsFolder + '/lodash/lodash.compat';
 
 var config = {
   baseUrl: 'temp/',
@@ -51,11 +52,6 @@ if (testType === 'backbone' || testType === 'deps') {
 requirejs.config(config);
 if (testType === 'exos') {
   define('jquery', function(){});
-  define('underscore', ['backbone'], function(Backbone){
-    var _ = Backbone.utils;
-    _.bind = function(fn, ctx) { return fn.bind(ctx); }
-    return _;
-  });
 }
 mocha.setup({ui: 'bdd', ignoreLeaks: true});
 // Wonderful hack to send a message to grunt from inside a mocha test.
@@ -107,14 +103,12 @@ window.addEventListener('DOMContentLoaded', function() {
     }
   };
 
-  require(specs, function() {
-    if (useDeps) {
-      run();
-    } else {
-      require(['backbone', 'NativeView'], function(Backbone, NativeView) {
-        Backbone.View = NativeView;
-        run();
-      });
-    }
-  });
+  if (useDeps === true) {
+    require(specs, run)
+  } else {
+    require(['backbone', 'NativeView'], function(Backbone, NativeView) {
+      Backbone.View = NativeView;
+      require(specs, run)
+    });
+  }
 }, false);

--- a/test/spec/collection_view_spec.coffee
+++ b/test/spec/collection_view_spec.coffee
@@ -6,7 +6,8 @@ define [
   'chaplin/views/view'
   'chaplin/views/collection_view'
   'chaplin/lib/sync_machine'
-], (_, jQuery, Model, Collection, View, CollectionView, SyncMachine) ->
+  'chaplin/lib/utils'
+], (_, jQuery, Model, Collection, View, CollectionView, SyncMachine, utils) ->
   'use strict'
 
   jQuery = null unless jQuery?.fn
@@ -86,9 +87,9 @@ define [
         collectionView.$list.children collectionView.itemSelector
       else
         if collectionView.itemSelector
-          (item for item in collectionView.list.children when Backbone.utils.matchesSelector item, collectionView.itemSelector)
+          (item for item in collectionView.listEl.children when utils.matchesSelector.call item, collectionView.itemSelector)
         else
-          collectionView.list.children
+          collectionView.listEl.children
 
     getAllChildren = ->
       if jQuery
@@ -176,7 +177,7 @@ define [
           expect(collectionView.$list).to.be.a jQuery
           expect(collectionView.$list.length).to.be 1
         else
-          expect(collectionView.list).to.be.a Element
+          expect(collectionView.listEl).to.be.a Element
 
         collectionView.renderAllItems()
         viewsMatchCollection()
@@ -735,10 +736,10 @@ define [
             children = getViewChildren()
             expect(children.length).to.be collection.length
           else
-            list = collectionView.list
+            list = collectionView.listEl
             expect(list).to.be.true
 
-            list2 = collectionView.find(collectionView.listSelector)
+            list2 = collectionView.el.querySelector(collectionView.listSelector)
             expect(list).to.be list2
 
             children = getViewChildren()
@@ -788,7 +789,7 @@ define [
           else
             {fallback} = collectionView
             expect(fallback).to.be.true
-            fallback2 = collectionView.find(collectionView.fallbackSelector)
+            fallback2 = collectionView.el.querySelector(collectionView.fallbackSelector)
             expect(fallback).to.be fallback2
 
         it 'should show the fallback element properly', ->
@@ -857,7 +858,7 @@ define [
           else
             {loading} = collectionView
             expect(loading).to.be.true
-            loading2 = collectionView.find(collectionView.loadingSelector)
+            loading2 = collectionView.el.querySelector(collectionView.loadingSelector)
             expect(loading).to.be loading2
 
         it 'should show the loading indicator properly', ->

--- a/test/spec/layout_spec.coffee
+++ b/test/spec/layout_spec.coffee
@@ -343,12 +343,8 @@ define [
       instance2 = new Test2View {region: 'test2'}
       instance3 = new Test2View {region: 'test0'}
 
-      if $
-        expect(instance2.container.attr('id')).to.be 'test2'
-        expect(instance3.container).to.be instance1.$el
-      else
-        expect(instance2.container.id).to.be 'test2'
-        expect(instance3.container).to.be instance1.el
+      expect(instance2.container.id).to.be 'test2'
+      expect(instance3.container).to.be instance1.el
 
       instance1.dispose()
       instance2.dispose()
@@ -375,10 +371,8 @@ define [
       instance1 = new Test1View()
       instance2 = new Test2View()
       instance3 = new Test3View {region: 'test2'}
-      if $
-        expect(instance3.container.attr('id')).to.be 'test5'
-      else
-        expect(instance3.container.id).to.be 'test5'
+
+      expect(instance3.container.id).to.be 'test5'
 
       instance1.dispose()
       instance2.dispose()
@@ -407,10 +401,8 @@ define [
       instance2 = new Test2View()
       instance2.stale = true
       instance3 = new Test3View {region: 'test2'}
-      if $
-        expect(instance3.container.attr('id')).to.be 'test2'
-      else
-        expect(instance3.container.id).to.be 'test2'
+
+      expect(instance3.container.id).to.be 'test2'
 
       instance1.dispose()
       instance2.dispose()


### PR DESCRIPTION
Finally had some time to work on #3. This PR is a WIP, tests still fails with the exo setup.

There's a few bug in the current version of test/initialize.js when tests are launched with the type=exos&useDeps=false query string. 

I've fixed locally some of them, but i currently encouter a problem with the NativeView shim.

When [NativeView replace BackboneView](https://github.com/akre54/chaplin/blob/bb-view-hooks/test/initialize.js#L114) in the test setup, Chaplin.View has aleardy been required, so it extends Backbone.View instead of NativeView. 

I'm a total noob with requireJS config, so any input is welcome
